### PR TITLE
Register Fix

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -15,12 +15,24 @@ JWT_ACCESS_EXPIRES_IN=3600
 JWT_REFRESH_EXPIRES_IN=604800
 JWT_ISSUER=gearfalcon
 
+# CORS Configuration
+ALLOWED_ORIGIN=http://localhost:3000,http://frontend:3000
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://frontend:3000
+CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,OPTIONS
+CORS_ALLOWED_HEADERS=Content-Type,Authorization,X-Requested-With
+
+
 # Email Configuration
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USERNAME=jgofiangga@gmail.com
 SMTP_PASSWORD=dvvrgdkdgtwdmgcy
 SMTP_FROM_EMAIL=jgofiangga@gmail.com
+
+# Logging
+LOG_LEVEL=debug
+LOG_CHANNEL=stack
+
 
 # API Configuration
 API_BASE_URL=http://localhost:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - /app/.next
     environment:
       - NODE_ENV=development
-      - NEXT_PUBLIC_API_URL=http://backend:80
+      - NEXT_PUBLIC_API_URL=http://localhost:8080
       - NEXT_TELEMETRY_DISABLED=1
     depends_on:
       backend:

--- a/src/Application/Services/EmailVerificationService.php
+++ b/src/Application/Services/EmailVerificationService.php
@@ -29,7 +29,8 @@ class EmailVerificationService
         
         $this->userRepository->update($user->id, [
             'verification_code' => $code,
-            'verification_code_expires_at' => date('Y-m-d H:i:s', strtotime('+15 minutes'))
+            // Set expiry to 5 minutes to align with auto-cleanup
+            'verification_code_expires_at' => date('Y-m-d H:i:s', strtotime('+5 minutes'))
         ]);
 
         $this->sendVerificationEmail($email, (string)$code);

--- a/src/Application/Services/UserRegistrationService.php
+++ b/src/Application/Services/UserRegistrationService.php
@@ -44,7 +44,8 @@ class UserRegistrationService
             'phone' => $data['phone'] ?? null,
             'is_verified' => false,
             'verification_code' => $verificationCode,
-            'verification_code_expires_at' => date('Y-m-d H:i:s', strtotime('+15 minutes'))
+            // Require verification within 5 minutes
+            'verification_code_expires_at' => date('Y-m-d H:i:s', strtotime('+5 minutes'))
         ]);
 
         return $user;

--- a/src/Infrastructure/Container.php
+++ b/src/Infrastructure/Container.php
@@ -43,7 +43,7 @@ use App\Presentation\Controllers\CatalogController;
 
 // Middleware
 use App\Presentation\Middleware\CorsMiddleware;
-use App\Presentation\Http\Middleware\AuthMiddleware;
+use App\Presentation\Middleware\AuthMiddleware;
 
 // Load .env with error handling
 try {
@@ -87,6 +87,17 @@ $jobRepository = new JobRepository(new Job);
 $technicianRepository = new TechnicianRepository(new Technician);
 $serviceCategoryRepository = new ServiceCategoryRepository(new ServiceCategory);
 $serviceRepository = new ServiceRepository(new Service);
+
+// Housekeeping: delete unverified users whose verification expired (>5 minutes)
+try {
+    $deletedCount = $userRepository->deleteExpiredUnverifiedUsers(5);
+    if ($deletedCount > 0) {
+        error_log("Cleanup: deleted {$deletedCount} expired unverified user(s)");
+    }
+} catch (\Throwable $e) {
+    // Do not block app if cleanup fails
+    error_log('Cleanup error (deleteExpiredUnverifiedUsers): ' . $e->getMessage());
+}
 
 // Services
 $userRegistrationService = new UserRegistrationService($userRepository);

--- a/src/Infrastructure/Repositories/UserRepository.php
+++ b/src/Infrastructure/Repositories/UserRepository.php
@@ -51,6 +51,24 @@ class UserRepository extends Repository
     {
         return $this->model->where('role', $role)->get();
     }
+
+    /**
+     * Delete users that are not verified and whose verification window expired.
+     * A user is considered expired if:
+     *  - is_verified = false
+     *  - verification_code_expires_at IS NOT NULL AND < NOW() - intervalMinutes
+     */
+    public function deleteExpiredUnverifiedUsers(int $intervalMinutes = 5): int
+    {
+        $threshold = date('Y-m-d H:i:s', strtotime("-{$intervalMinutes} minutes"));
+
+        // Use query builder to perform a single delete
+        return $this->model
+            ->where('is_verified', false)
+            ->whereNotNull('verification_code_expires_at')
+            ->where('verification_code_expires_at', '<', $threshold)
+            ->delete();
+    }
 }
 
 

--- a/src/Presentation/Http/HttpKernel.php
+++ b/src/Presentation/Http/HttpKernel.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Presentation\Http;
 
-use App\Presentation\Http\Middleware\AuthMiddleware;
+use App\Presentation\Middleware\AuthMiddleware;
 use FastRoute\Dispatcher;
 use App\Presentation\Middleware\CorsMiddleware;
 

--- a/src/Presentation/Middleware/AuthMiddleware.php
+++ b/src/Presentation/Middleware/AuthMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Presentation\Http\Middleware;
+namespace App\Presentation\Middleware;
 
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;


### PR DESCRIPTION
# Align auth API, fix frontend-backend connectivity, and auto-cleanup unverified users after 5 minutes


## Summary
Standardized frontend auth endpoints and response types to match backend.
Fixed frontend API base URL in Docker so browser clients reach the backend.
Removed unused refresh flow and simplified error handling.
Enforced 5-minute email verification window and added automatic cleanup of expired, unverified users.
## Changes
### Frontend
src/app/shared/services/AuthService.ts
Aligned endpoints: /auth/login, /auth/register, /auth/verify-email, /auth/resend-verification.
Updated LoginResponse to backend shape: { success, token, expires_in, user }.
Removed unused token refresh API usage.
Enhanced Axios error logging with message, statusText, baseURL, method, and network/timeout hints.
src/app/shared/services/axiosClient.ts
Removed refresh-token flow (no backend endpoint).
Simplified 401 handling: clear in-memory token; no automatic retry.
Removed refresh-related queue and secondary Axios instance.
src/app/login/hooks/useLogin.ts
Updated to use token (instead of access_token) from login response.
### Docker/Config
gearfalcon-api/docker-compose.yml
Set NEXT_PUBLIC_API_URL=http://localhost:8080 for the frontend service to work when accessed from a browser on the host.
### Backend
src/Application/Services/UserRegistrationService.php
Set verification_code_expires_at to +5 minutes.
src/Application/Services/EmailVerificationService.php
Set verification code expiry to +5 minutes for send and resend paths.
src/Infrastructure/Repositories/UserRepository.php
Added deleteExpiredUnverifiedUsers(int $intervalMinutes = 5): int to delete unverified users with expired verification window.
src/Infrastructure/Container.php
Invokes deleteExpiredUnverifiedUsers(5) on bootstrap; logs results, non-blocking on failure.
## Rationale
Frontend was using mixed /api/auth/* and /auth/* endpoints; backend exposes /auth/*.
Frontend expected { access_token } but backend returns { token }.
Browser could not resolve http://backend:80; moved to http://localhost:8080 for host access.
No refresh endpoint exists; removed dead code and simplified error handling.
Product requirement: auto-delete unverified accounts after 5 minutes to keep DB clean.
## How to Test
Connectivity
Start stack: docker-compose up -d.
Verify health: http://localhost:8080/health returns 200 JSON.
Frontend loads at http://localhost:3000.
### Auth flows
Register at http://localhost:3000/register.
Observe request to POST http://localhost:8080/auth/register.
Try login at http://localhost:3000/login; token should be stored in memory; requests include Authorization: Bearer <token>.
Verification expiry and cleanup
Register a user and do not verify.
Wait >5 minutes.
Trigger any backend request (e.g., load /health) to execute cleanup.
Confirm user is deleted:
Inside DB container:
docker exec -it gearfalcon-api-db-1 mysql -u root -p -e "USE gearfalcon_db_dev; SELECT * FROM users WHERE email='you@example.com';"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Verification codes now expire after 5 minutes, tightening the signup verification window.

- Chores
  - Added configurable CORS and logging options via environment variables.
  - Updated the frontend API URL to http://localhost:8080 for local development.
  - Automatic cleanup removes accounts left unverified after 5 minutes during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->